### PR TITLE
feat: implement Dice screen, components, and rolling logic

### DIFF
--- a/src/components/dice/DiceCountSelector.tsx
+++ b/src/components/dice/DiceCountSelector.tsx
@@ -1,0 +1,154 @@
+/**
+ * DiceCountSelector — increment / decrement control for choosing how many
+ * dice to roll (1–6 per ADR-13).
+ *
+ * Touch targets are enforced at 48×48 dp (WCAG NFR-A2). Decrement is
+ * disabled at `min` and increment is disabled at `max`.
+ */
+
+import React, { useCallback } from 'react';
+import { Insets, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { colors, spacing, typography, borderRadius, touchTarget } from '../../styles/theme';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MIN = 1;
+const DEFAULT_MAX = 6;
+
+/** Extra tap area around small icon buttons to keep NFR-A2 (48×48 dp). */
+const BUTTON_HIT_SLOP: Insets = { top: 8, bottom: 8, left: 8, right: 8 };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DiceCountSelectorProps {
+  /** Current dice count to display */
+  count: number;
+  /** Called when the user taps "−" and count is above `min` */
+  onDecrement: () => void;
+  /** Called when the user taps "+" and count is below `max` */
+  onIncrement: () => void;
+  /** Minimum allowed value (default: 1) */
+  min?: number;
+  /** Maximum allowed value (default: 6) */
+  max?: number;
+  /** Disable both buttons (e.g. while animation is running) */
+  disabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DiceCountSelector({
+  count,
+  onDecrement,
+  onIncrement,
+  min = DEFAULT_MIN,
+  max = DEFAULT_MAX,
+  disabled = false,
+}: DiceCountSelectorProps): React.ReactElement {
+  const canDecrement = !disabled && count > min;
+  const canIncrement = !disabled && count < max;
+
+  const handleDecrement = useCallback(() => {
+    if (canDecrement) onDecrement();
+  }, [canDecrement, onDecrement]);
+
+  const handleIncrement = useCallback(() => {
+    if (canIncrement) onIncrement();
+  }, [canIncrement, onIncrement]);
+
+  return (
+    <View style={styles.container} accessibilityRole="adjustable" accessibilityLabel={`Number of dice: ${count}`}>
+      <TouchableOpacity
+        style={[styles.button, !canDecrement && styles.buttonDisabled]}
+        onPress={handleDecrement}
+        disabled={!canDecrement}
+        accessibilityRole="button"
+        accessibilityLabel="Decrease dice count"
+        accessibilityState={{ disabled: !canDecrement }}
+        hitSlop={BUTTON_HIT_SLOP}
+      >
+        <Text style={[styles.buttonLabel, !canDecrement && styles.buttonLabelDisabled]}>
+          −
+        </Text>
+      </TouchableOpacity>
+
+      <View style={styles.countContainer}>
+        <Text style={styles.countText} accessibilityLabel={`${count} dice selected`}>
+          {count}
+        </Text>
+        <Text style={styles.countCaption}>
+          {count === 1 ? 'die' : 'dice'}
+        </Text>
+      </View>
+
+      <TouchableOpacity
+        style={[styles.button, !canIncrement && styles.buttonDisabled]}
+        onPress={handleIncrement}
+        disabled={!canIncrement}
+        accessibilityRole="button"
+        accessibilityLabel="Increase dice count"
+        accessibilityState={{ disabled: !canIncrement }}
+        hitSlop={BUTTON_HIT_SLOP}
+      >
+        <Text style={[styles.buttonLabel, !canIncrement && styles.buttonLabelDisabled]}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+  },
+  button: {
+    width: touchTarget.minSize,
+    height: touchTarget.minSize,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.35,
+  },
+  buttonLabel: {
+    color: colors.textInverse,
+    fontSize: 28,
+    fontWeight: '600',
+    lineHeight: 32,
+    textAlign: 'center',
+  },
+  buttonLabelDisabled: {
+    color: colors.textInverse,
+  },
+  countContainer: {
+    alignItems: 'center',
+    minWidth: 56,
+  },
+  countText: {
+    ...typography.h1,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  countCaption: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    textTransform: 'lowercase',
+  },
+});

--- a/src/components/dice/DiceDisplay.tsx
+++ b/src/components/dice/DiceDisplay.tsx
@@ -1,0 +1,155 @@
+/**
+ * DiceDisplay — renders the dice faces either in animated spinning state
+ * or settled with their final values.
+ *
+ * Layout adapts to the number of dice:
+ *   1–3 dice : single horizontal row
+ *   4–6 dice : wrapping flex row (naturally forms a 2-row grid)
+ *
+ * During animation each face shows a "?" placeholder spinning via
+ * RollAnimation. After the animation completes the actual result numbers
+ * are shown statically.
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View, ViewStyle } from 'react-native';
+import { colors, spacing, typography, borderRadius, elevation } from '../../styles/theme';
+import { RollAnimation } from './RollAnimation';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DiceDisplayProps {
+  /**
+   * Array of result values (1–6). When empty and `isAnimating` is true
+   * the component renders `diceCount` spinning placeholder dice.
+   */
+  results: number[];
+  /** Number of dice currently selected — used to render placeholders. */
+  diceCount: number;
+  /** When true every die is wrapped in a RollAnimation. */
+  isAnimating: boolean;
+  /**
+   * Called once when the first die's roll animation finishes. Parent can
+   * use this to trigger result generation and state transitions.
+   */
+  onAnimationComplete?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: single die face
+// ---------------------------------------------------------------------------
+
+interface DieFaceProps {
+  /** Value to display; undefined renders a "?" placeholder. */
+  value?: number;
+  style?: ViewStyle;
+}
+
+function DieFace({ value, style }: DieFaceProps): React.ReactElement {
+  const displayText = value !== undefined ? String(value) : '?';
+  return (
+    <View
+      style={[styles.dieFace, style]}
+      accessibilityRole="text"
+      accessibilityLabel={value !== undefined ? `Die showing ${value}` : 'Die rolling'}
+    >
+      <Text style={styles.dieValue}>{displayText}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DiceDisplay({
+  results,
+  diceCount,
+  isAnimating,
+  onAnimationComplete,
+}: DiceDisplayProps): React.ReactElement {
+  // Determine how many dice to display.
+  const count = isAnimating ? diceCount : results.length;
+
+  if (count === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyText}>Select dice count and tap Roll</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.diceRow, count > 3 && styles.diceWrap]}>
+      {Array.from({ length: count }, (_, index) => {
+        const value = results[index];
+
+        if (isAnimating) {
+          return (
+            <RollAnimation
+              key={index}
+              isAnimating={isAnimating}
+              // Only the first die triggers the completion callback.
+              onAnimationComplete={index === 0 ? onAnimationComplete : undefined}
+            >
+              <DieFace />
+            </RollAnimation>
+          );
+        }
+
+        return <DieFace key={index} value={value} />;
+      })}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  diceRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  diceWrap: {
+    flexWrap: 'wrap',
+  },
+  dieFace: {
+    width: 64,
+    height: 64,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.surface,
+    borderWidth: 2,
+    borderColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Elevation / shadow for a card-like "physical die" feel.
+    elevation: elevation.low,
+    shadowColor: colors.secondary,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+    margin: spacing.xxs,
+  },
+  dieValue: {
+    ...typography.score,
+    fontSize: 32,
+    lineHeight: 40,
+    color: colors.primary,
+    textAlign: 'center',
+  },
+  emptyContainer: {
+    paddingVertical: spacing.lg,
+    alignItems: 'center',
+  },
+  emptyText: {
+    ...typography.body,
+    color: colors.textSecondary,
+    textAlign: 'center',
+  },
+});

--- a/src/components/dice/RollAnimation.tsx
+++ b/src/components/dice/RollAnimation.tsx
@@ -1,0 +1,87 @@
+/**
+ * RollAnimation — reusable spinning animation wrapper for a single die.
+ *
+ * Uses the built-in React Native Animated API (per ADR-4). When `isAnimating`
+ * is true, the component spins its children using the `createDiceRollAnimation`
+ * helper (8 iterations × 150 ms = 1 200 ms, well within the 0.5–1.5 s spec).
+ *
+ * Only one instance per dice set needs to receive `onAnimationComplete`; the
+ * rest simply stop once `isAnimating` returns to false.
+ */
+
+import React, { useEffect, useRef, useMemo } from 'react';
+import { Animated, ViewStyle } from 'react-native';
+import { createDiceRollAnimation } from '../../utils/animations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RollAnimationProps {
+  /** When true the child spins; when false it is rendered statically. */
+  isAnimating: boolean;
+  /**
+   * Called once when the animation sequence finishes naturally (i.e. after all
+   * loop iterations complete). Ignored if `isAnimating` becomes false before
+   * the animation ends.
+   */
+  onAnimationComplete?: () => void;
+  /** Content to apply the spinning transform to. */
+  children: React.ReactNode;
+  /** Additional styles forwarded to the Animated.View wrapper. */
+  style?: ViewStyle;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RollAnimation({
+  isAnimating,
+  onAnimationComplete,
+  children,
+  style,
+}: RollAnimationProps): React.ReactElement {
+  // Create a stable animation controller for this instance.
+  const controller = useMemo(() => createDiceRollAnimation(), []);
+  // Keep a ref to the running composite animation so we can stop it on cleanup.
+  const animRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  useEffect(() => {
+    if (!isAnimating) {
+      // Stop any in-progress animation and reset to the neutral position.
+      animRef.current?.stop();
+      controller.reset();
+      return;
+    }
+
+    const anim = controller.spin();
+    animRef.current = anim;
+
+    anim.start(({ finished }: { finished: boolean }) => {
+      if (finished) {
+        controller.reset();
+        onAnimationComplete?.();
+      }
+    });
+
+    return () => {
+      anim.stop();
+    };
+    // onAnimationComplete is intentionally excluded from deps — callers may
+    // pass inline arrows; we don't want to restart the animation if only the
+    // callback reference changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAnimating]);
+
+  const rotate = controller.spinValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  return (
+    <Animated.View style={[style, { transform: [{ rotate }] }]}>
+      {children}
+    </Animated.View>
+  );
+}

--- a/src/components/dice/index.ts
+++ b/src/components/dice/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Barrel export for the dice component library.
+ *
+ * Import dice components from this single entry point:
+ *   import { DiceCountSelector, DiceDisplay, RollAnimation } from '../components/dice';
+ */
+
+export { DiceCountSelector } from './DiceCountSelector';
+export type { DiceCountSelectorProps } from './DiceCountSelector';
+
+export { DiceDisplay } from './DiceDisplay';
+export type { DiceDisplayProps } from './DiceDisplay';
+
+export { RollAnimation } from './RollAnimation';
+export type { RollAnimationProps } from './RollAnimation';

--- a/src/screens/dice/DiceScreen.tsx
+++ b/src/screens/dice/DiceScreen.tsx
@@ -1,31 +1,225 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+/**
+ * DiceScreen — full dice rolling interface.
+ *
+ * Features:
+ *  - Dice count selector (1–6 dice, per ADR-13)
+ *  - "Roll" button that triggers RollAnimation and generates d6 results
+ *  - Animated dice display (spinning → settled values)
+ *  - Total sum display
+ *  - "Roll Again" button reuses the same dice count
+ *  - "Clear" button resets results
+ *
+ * State management:
+ *  - diceCount   : how many dice to roll (1–6)
+ *  - results     : array of die values after animation completes
+ *  - isAnimating : true while the spin animation is in progress
+ *
+ * Animations use React Native's built-in Animated API (ADR-4).
+ * Orientation is supported via useWindowBreakpoints (ADR-16).
+ */
 
+import React, { useCallback, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { ScreenContainer } from '../../components/common/ScreenContainer';
+import { Button } from '../../components/common/Button';
+import { DiceCountSelector, DiceDisplay } from '../../components/dice';
 import { RootStackScreenProps } from '../../navigation/types';
+import { DiceRoller } from '../../services/dice/DiceRoller';
+import { colors, spacing, typography } from '../../styles/theme';
+import { useWindowBreakpoints } from '../../styles/responsive';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 type Props = RootStackScreenProps<'Dice'>;
 
-/**
- * Dice screen — dice rolling interface.
- * Full implementation completed by TASK-005.
- */
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIN_DICE = 1;
+const MAX_DICE = 6;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function DiceScreen(_props: Props): React.JSX.Element {
+  const [diceCount, setDiceCount] = useState(1);
+  const [results, setResults] = useState<number[]>([]);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const { isTablet } = useWindowBreakpoints();
+
+  // -------------------------------------------------------------------------
+  // Handlers
+  // -------------------------------------------------------------------------
+
+  const handleDecrement = useCallback(() => {
+    setDiceCount((prev: number) => Math.max(MIN_DICE, prev - 1));
+  }, []);
+
+  const handleIncrement = useCallback(() => {
+    setDiceCount((prev: number) => Math.min(MAX_DICE, prev + 1));
+  }, []);
+
+  const handleRoll = useCallback(() => {
+    if (isAnimating) return;
+    // Clear previous results and start the animation.
+    setResults([]);
+    setIsAnimating(true);
+  }, [isAnimating]);
+
+  const handleAnimationComplete = useCallback(() => {
+    // Generate results now that animation is done and display them.
+    setResults(DiceRoller.rollDice(diceCount));
+    setIsAnimating(false);
+  }, [diceCount]);
+
+  const handleClear = useCallback(() => {
+    if (isAnimating) return;
+    setResults([]);
+  }, [isAnimating]);
+
+  // -------------------------------------------------------------------------
+  // Derived values
+  // -------------------------------------------------------------------------
+
+  const total = results.reduce((sum: number, val: number) => sum + val, 0);
+  const hasResults = results.length > 0;
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Dice</Text>
-    </View>
+    <ScreenContainer>
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          isTablet && styles.scrollContentTablet,
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ---- Header ---- */}
+        <Text style={styles.title} accessibilityRole="header">
+          Roll Dice
+        </Text>
+
+        {/* ---- Dice count selector ---- */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Number of Dice</Text>
+          <DiceCountSelector
+            count={diceCount}
+            onDecrement={handleDecrement}
+            onIncrement={handleIncrement}
+            disabled={isAnimating}
+          />
+        </View>
+
+        {/* ---- Animated dice display ---- */}
+        <View style={styles.section}>
+          <DiceDisplay
+            results={results}
+            diceCount={diceCount}
+            isAnimating={isAnimating}
+            onAnimationComplete={handleAnimationComplete}
+          />
+        </View>
+
+        {/* ---- Total sum ---- */}
+        {hasResults && (
+          <View style={styles.totalContainer} accessibilityLiveRegion="polite">
+            <Text style={styles.totalLabel}>Total</Text>
+            <Text
+              style={styles.totalValue}
+              accessibilityLabel={`Total: ${total}`}
+            >
+              {total}
+            </Text>
+          </View>
+        )}
+
+        {/* ---- Action buttons ---- */}
+        <View style={styles.actions}>
+          <Button
+            label={hasResults ? 'Roll Again' : 'Roll'}
+            onPress={handleRoll}
+            variant="primary"
+            size="large"
+            disabled={isAnimating}
+          />
+
+          {hasResults && !isAnimating && (
+            <Button
+              label="Clear"
+              onPress={handleClear}
+              variant="secondary"
+              size="medium"
+            />
+          )}
+        </View>
+      </ScrollView>
+    </ScreenContainer>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  scrollContent: {
+    flexGrow: 1,
     alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#fff',
+    paddingBottom: spacing.xxl,
+    gap: spacing.xl,
+  },
+  scrollContentTablet: {
+    paddingHorizontal: spacing.xl,
   },
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+    ...typography.h1,
+    color: colors.text,
+    textAlign: 'center',
+    marginTop: spacing.sm,
+  },
+  section: {
+    alignItems: 'center',
+    width: '100%',
+  },
+  sectionLabel: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  totalContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.xl,
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: colors.primary,
+    minWidth: 120,
+  },
+  totalLabel: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  totalValue: {
+    ...typography.score,
+    color: colors.primary,
+    textAlign: 'center',
+  },
+  actions: {
+    alignItems: 'center',
+    gap: spacing.md,
+    width: '100%',
   },
 });


### PR DESCRIPTION
## Summary
Implements the Dice feature screen with a dice count selector, spin animation, and results display using React Native's built-in Animated API (per ADR-4).

Closes #11

## Changes
- **`src/screens/dice/DiceScreen.tsx`** — Full dice rolling interface with state management (`diceCount`, `results`, `isAnimating`), Roll/Roll Again/Clear buttons, total sum display, and responsive layout via `useWindowBreakpoints`
- **`src/components/dice/DiceCountSelector.tsx`** — Increment/decrement selector for 1–6 dice with 48×48 dp touch targets (WCAG NFR-A2), disabled states, and accessibility labels
- **`src/components/dice/DiceDisplay.tsx`** — Renders N spinning placeholder dice during animation, then N static die faces showing individual results after animation completes
- **`src/components/dice/RollAnimation.tsx`** — Self-contained spinning animation wrapper using `createDiceRollAnimation` (8 iterations × 150 ms = 1.2 s); accepts `isAnimating` + optional `onAnimationComplete` callback
- **`src/components/dice/index.ts`** — Barrel export for the dice component library

## Design Decisions
- **Animation timing**: Reused `createDiceRollAnimation()` from `src/utils/animations.ts` (already architected for this use case). 8 loops × 150 ms = 1 200 ms — within the required 0.5–1.5 s range.
- **Results generated after animation**: `DiceRoller.rollDice()` is called inside `handleAnimationComplete` so the display transitions cleanly from spinning → final values. The `onAnimationComplete` callback is only wired to the first die in `DiceDisplay` to avoid N simultaneous callbacks.
- **Self-contained `RollAnimation`**: Each instance creates its own `Animated.Value` so multiple dice can spin independently. The parent controls `isAnimating`; the component manages start/stop internally.
- **Empty state in `DiceDisplay`**: When neither animating nor having results, a prompt text is shown instead of blank space.

## Acceptance Criteria
- [x] DiceScreen renders dice count selector (buttons to select 1-6)
- [x] "Roll" button triggers animation and generates random results
- [x] Animation runs for ~1.2 seconds (within 0.5–1.5 s requirement) with spinning effect
- [x] After animation, individual die results and sum are displayed
- [x] User can roll again without changing dice count ("Roll Again" button)
- [x] Touch targets (buttons, Roll) are minimum 48×48 dp
- [x] Screen respects safe area (via `ScreenContainer`) and landscape orientation (via `useWindowBreakpoints`)

## Verification
- [ ] Type check passes (pre-existing infra errors — missing node_modules — unrelated to this PR; my code has no new type errors)
- [ ] Lint passes (ESLint config uses legacy `.eslintrc.json` format; lint tooling unavailable in this environment)
- [ ] Tests pass (no new test files required per task scope)

## Notes
The TypeScript `tsc --noEmit` run shows errors for `react`, `react-native`, and other missing modules — these are pre-existing infrastructure issues (node_modules not installed in this worktree) that affect every file in the repo, not just my additions. The two errors specific to my code (`finished: any`, `prev: any`) were fixed with explicit type annotations.
