### PR TITLE
feat: Implement Lottery screen with multi-touch tracking and gesture handler

### DIFF
--- a/src/components/lottery/TouchCircle.tsx
+++ b/src/components/lottery/TouchCircle.tsx
@@ -1,0 +1,160 @@
+/**
+ * TouchCircle — visual circle representing a single active touch point
+ * in the Lottery feature.
+ *
+ * Each circle is positioned absolutely at (x, y) on the touch surface,
+ * centered on the contact point. Animations use the built-in React Native
+ * Animated API (ADR-4):
+ *   - Initial appear: spring scale 0 → 1
+ *   - Winner grow:    spring scale 1 → WINNER_SCALE (isWinner + growing)
+ *   - Non-winner fade: timing opacity 1 → 0 (fading)
+ *
+ * Accessibility: each circle has an accessibilityRole and label.
+ * The winner trophy icon meets WCAG AA contrast (#FFFFFF on colored background).
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Diameter of a normal touch circle in density-independent pixels. */
+const CIRCLE_SIZE = 80;
+
+/** Scale factor applied to the winner circle's grow animation. */
+const WINNER_SCALE = 2.0;
+
+/** Duration of the non-winner fade-out animation in milliseconds. */
+const FADE_DURATION_MS = 600;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface TouchCircleProps {
+  /** X coordinate of the circle centre (relative to the touch surface). */
+  x: number;
+  /** Y coordinate of the circle centre (relative to the touch surface). */
+  y: number;
+  /** Background fill colour — must be a WCAG AA compliant lottery colour. */
+  color: string;
+  /** Whether this circle is the selected winner. */
+  isWinner: boolean;
+  /**
+   * When true, plays the celebration / winner grow animation.
+   * Meaningful only when `isWinner` is also true.
+   */
+  growing: boolean;
+  /**
+   * When true, animates opacity to 0 (non-winner fade-out).
+   * Has no effect on the winner circle.
+   */
+  fading?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Animated circle anchored at the touch contact point.
+ * Appears with a spring animation on mount and responds to winner / fading states.
+ */
+export function TouchCircle({
+  x,
+  y,
+  color,
+  isWinner,
+  growing,
+  fading = false,
+}: TouchCircleProps): React.JSX.Element {
+  const scaleAnim = useRef(new Animated.Value(0)).current;
+  const opacityAnim = useRef(new Animated.Value(1)).current;
+
+  // Initial appear: spring from invisible to full size.
+  useEffect(() => {
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      friction: 5,
+      tension: 40,
+      useNativeDriver: true,
+    }).start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Run once on mount only.
+
+  // Winner grow: scale up to WINNER_SCALE when this circle wins.
+  useEffect(() => {
+    if (isWinner && growing) {
+      Animated.spring(scaleAnim, {
+        toValue: WINNER_SCALE,
+        friction: 3,
+        tension: 25,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [isWinner, growing, scaleAnim]);
+
+  // Non-winner fade-out: animate opacity to 0.
+  useEffect(() => {
+    if (fading) {
+      Animated.timing(opacityAnim, {
+        toValue: 0,
+        duration: FADE_DURATION_MS,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [fading, opacityAnim]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.circle,
+        {
+          backgroundColor: color,
+          // Centre the circle on the contact point.
+          left: x - CIRCLE_SIZE / 2,
+          top: y - CIRCLE_SIZE / 2,
+          transform: [{ scale: scaleAnim }],
+          opacity: opacityAnim,
+        },
+      ]}
+      accessibilityRole="image"
+      accessibilityLabel={isWinner ? 'Winner circle' : 'Player touch circle'}
+    >
+      {isWinner && (
+        <Text style={styles.winnerIcon} accessibilityLabel="winner star">
+          ★
+        </Text>
+      )}
+    </Animated.View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  circle: {
+    position: 'absolute',
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    borderRadius: CIRCLE_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Shadow (iOS)
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.35,
+    shadowRadius: 6,
+    // Shadow (Android)
+    elevation: 8,
+  },
+  winnerIcon: {
+    fontSize: 28,
+    color: '#FFFFFF',
+    fontWeight: '700',
+  },
+});

--- a/src/components/lottery/TouchSurface.tsx
+++ b/src/components/lottery/TouchSurface.tsx
@@ -1,0 +1,206 @@
+/**
+ * TouchSurface — full-screen multi-touch tracking surface for the Lottery feature.
+ *
+ * Uses React Native Gesture Handler's Gesture API (ADR-3) to reliably track
+ * up to `maxTouches` simultaneous touch points on both iOS and Android.
+ *
+ * Implementation notes:
+ *  - Uses `Gesture.Manual()` for fine-grained access to individual touch events.
+ *  - `stateManager.activate()` is called on first touch so subsequent events
+ *    (moves, lifts) continue to fire.
+ *  - A `GestureHandlerRootView` wraps the surface because the app root (App.tsx)
+ *    does not yet include one; nesting is supported by RNGH.
+ *  - Callback references and flags are held in refs so the gesture object never
+ *    needs to be recreated (stable `useMemo` with empty dep array).
+ *  - The 9th (and beyond) touch triggers `onMaxTouchesExceeded` and is silently
+ *    dropped, per ADR-12.
+ */
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+  type GestureTouchEvent,
+  type GestureStateManager,
+} from 'react-native-gesture-handler';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single raw touch point as reported by the native gesture system. */
+export interface RawTouchPoint {
+  /** Stringified native touch identifier — unique per active finger. */
+  id: string;
+  /** X coordinate relative to the top-left corner of this surface. */
+  x: number;
+  /** Y coordinate relative to the top-left corner of this surface. */
+  y: number;
+}
+
+export interface TouchSurfaceProps {
+  /**
+   * Called whenever the set of active touches changes (finger down, move, or up).
+   * Receives the **complete** current list of tracked touches.
+   */
+  onTouchesChange: (touches: RawTouchPoint[]) => void;
+  /**
+   * Called when an additional touch is rejected because `maxTouches` are
+   * already active (i.e. the 9th finger per ADR-12).
+   */
+  onMaxTouchesExceeded?: () => void;
+  /**
+   * Maximum simultaneous touches to track.
+   * Defaults to 8 per ADR-12 (`MAX_LOTTERY_TOUCHES`).
+   */
+  maxTouches?: number;
+  /**
+   * When `true` the surface ignores all touch events and does not invoke
+   * callbacks. Use this to freeze touch state after a winner is selected.
+   */
+  disabled?: boolean;
+  /** Content rendered on top of the touch surface (e.g. TouchCircles). */
+  children?: React.ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Full-screen touch tracking surface.
+ *
+ * Wrap children with this component to receive multi-touch coordinate updates
+ * via `onTouchesChange`. Enforces a hard cap of `maxTouches` simultaneous
+ * touches — excess touches are silently dropped.
+ */
+export function TouchSurface({
+  onTouchesChange,
+  onMaxTouchesExceeded,
+  maxTouches = 8,
+  disabled = false,
+  children,
+}: TouchSurfaceProps): React.JSX.Element {
+  // Internal map: touchId → RawTouchPoint.  Mutated synchronously in gesture
+  // callbacks to avoid stale closures without needing reactive state.
+  const activeTouchesRef = useRef<Map<string, RawTouchPoint>>(new Map());
+
+  // -------------------------------------------------------------------------
+  // Callback refs — updated every render so the gesture (created once) always
+  // calls the latest versions without being recreated.
+  // -------------------------------------------------------------------------
+  const disabledRef = useRef(disabled);
+  const maxTouchesRef = useRef(maxTouches);
+  const onTouchesChangeRef = useRef(onTouchesChange);
+  const onMaxTouchesExceededRef = useRef(onMaxTouchesExceeded);
+
+  useEffect(() => {
+    disabledRef.current = disabled;
+  }, [disabled]);
+
+  useEffect(() => {
+    maxTouchesRef.current = maxTouches;
+  }, [maxTouches]);
+
+  useEffect(() => {
+    onTouchesChangeRef.current = onTouchesChange;
+  }, [onTouchesChange]);
+
+  useEffect(() => {
+    onMaxTouchesExceededRef.current = onMaxTouchesExceeded;
+  }, [onMaxTouchesExceeded]);
+
+  // -------------------------------------------------------------------------
+  // Gesture — created once (empty dep array) and reads all mutable state
+  // through refs to stay up to date without recreating.
+  // -------------------------------------------------------------------------
+  const gesture = useMemo(
+    () =>
+      Gesture.Manual()
+        .onTouchesDown((event: GestureTouchEvent, stateManager: GestureStateManager) => {
+          // Transition to ACTIVE so move / up events continue to fire.
+          stateManager.activate();
+
+          if (disabledRef.current) return;
+
+          let exceeded = false;
+          for (const touch of event.changedTouches) {
+            const id = String(touch.id);
+            if (activeTouchesRef.current.size >= maxTouchesRef.current) {
+              exceeded = true;
+              continue; // Ignore touches beyond the limit (ADR-12).
+            }
+            activeTouchesRef.current.set(id, { id, x: touch.x, y: touch.y });
+          }
+
+          if (exceeded) {
+            onMaxTouchesExceededRef.current?.();
+          }
+
+          onTouchesChangeRef.current(
+            Array.from(activeTouchesRef.current.values()),
+          );
+        })
+        .onTouchesMove((event: GestureTouchEvent) => {
+          if (disabledRef.current) return;
+
+          for (const touch of event.changedTouches) {
+            const id = String(touch.id);
+            // Only update touches that are already tracked (ignore overflow ones).
+            if (activeTouchesRef.current.has(id)) {
+              activeTouchesRef.current.set(id, { id, x: touch.x, y: touch.y });
+            }
+          }
+
+          onTouchesChangeRef.current(
+            Array.from(activeTouchesRef.current.values()),
+          );
+        })
+        .onTouchesUp((event: GestureTouchEvent) => {
+          if (disabledRef.current) return;
+
+          for (const touch of event.changedTouches) {
+            activeTouchesRef.current.delete(String(touch.id));
+          }
+
+          onTouchesChangeRef.current(
+            Array.from(activeTouchesRef.current.values()),
+          );
+        })
+        .onTouchesCancelled(() => {
+          // All pointers lost — clear everything.
+          activeTouchesRef.current.clear();
+          onTouchesChangeRef.current([]);
+        }),
+    [], // Intentionally empty: state is accessed through refs above.
+  );
+
+  return (
+    <GestureHandlerRootView style={styles.rootView}>
+      <GestureDetector gesture={gesture}>
+        {/*
+         * collapsable={false} prevents the native view from being merged
+         * with its parent, which could displace touch coordinate origins.
+         */}
+        <View style={styles.surface} collapsable={false}>
+          {children}
+        </View>
+      </GestureDetector>
+    </GestureHandlerRootView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  rootView: {
+    flex: 1,
+  },
+  surface: {
+    flex: 1,
+  },
+});

--- a/src/screens/lottery/LotteryScreen.tsx
+++ b/src/screens/lottery/LotteryScreen.tsx
@@ -1,31 +1,480 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+/**
+ * LotteryScreen — multi-touch player selection (Lottery feature).
+ *
+ * Feature flow (FR-L1 – FR-L10):
+ *   1. Players place fingers simultaneously — a coloured circle appears for each (FR-L2/L3).
+ *   2. Once 2+ fingers are present and stable, a 3-second countdown begins (FR-L4).
+ *   3. If any finger is added or removed the countdown resets (FR-L9).
+ *   4. After 3 stable seconds, `LotteryEngine.selectWinner()` is called (FR-L6).
+ *   5. The winner circle grows; all other circles fade out (FR-L7).
+ *   6. A winner announcement is displayed (FR-L8).
+ *   7. "Play Again" resets the surface for another round (FR-L10).
+ *   8. A 9th simultaneous touch is rejected with a brief overlay message (ADR-12).
+ *
+ * State management:
+ *   - activeTouches  : Touch[] — current tracked touches with assigned colours.
+ *   - winner         : Touch | null — selected winner, null until countdown completes.
+ *   - countdown      : number | null — visual countdown in seconds (null = not counting).
+ *   - showMaxMessage : boolean — brief "max 8 players" overlay.
+ *   - roundKey       : number — incremented on "Play Again" to remount TouchSurface.
+ *
+ * Animations use React Native's built-in Animated API (ADR-4).
+ * Multi-touch tracking uses React Native Gesture Handler (ADR-3).
+ */
 
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { TouchCircle } from '../../components/lottery/TouchCircle';
+import {
+  RawTouchPoint,
+  TouchSurface,
+} from '../../components/lottery/TouchSurface';
 import { RootStackScreenProps } from '../../navigation/types';
+import { LotteryEngine } from '../../services/lottery/LotteryEngine';
+import { colors, spacing, typography } from '../../styles/theme';
+import { Touch } from '../../types/Touch';
+import {
+  LOTTERY_STABILITY_MS,
+  MAX_LOTTERY_TOUCHES,
+} from '../../utils/constants';
+import {
+  LOTTERY_BLUE,
+  LOTTERY_BROWN,
+  LOTTERY_COLORS,
+  LOTTERY_GREEN,
+  LOTTERY_ORANGE,
+  LOTTERY_PINK,
+  LOTTERY_PURPLE,
+  LOTTERY_RED,
+  LOTTERY_TEAL,
+} from '../../utils/colors';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 type Props = RootStackScreenProps<'Lottery'>;
 
-/**
- * Lottery screen — multi-touch player selection.
- * Full implementation completed by TASK-009.
- */
+/** Human-readable names for lottery circle colours (used in winner announcement). */
+const COLOR_NAMES: Record<string, string> = {
+  [LOTTERY_RED]: 'Red',
+  [LOTTERY_BLUE]: 'Blue',
+  [LOTTERY_GREEN]: 'Green',
+  [LOTTERY_PURPLE]: 'Purple',
+  [LOTTERY_ORANGE]: 'Orange',
+  [LOTTERY_TEAL]: 'Teal',
+  [LOTTERY_PINK]: 'Pink',
+  [LOTTERY_BROWN]: 'Brown',
+};
+
+/** Minimum players required to start the countdown. */
+const MIN_PLAYERS = 2;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function LotteryScreen(_props: Props): React.JSX.Element {
+  // -------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------
+  const [activeTouches, setActiveTouches] = useState<Touch[]>([]);
+  const [winner, setWinner] = useState<Touch | null>(null);
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const [showMaxMessage, setShowMaxMessage] = useState(false);
+  /** Incremented on Play Again to remount TouchSurface and reset its internal state. */
+  const [roundKey, setRoundKey] = useState(0);
+
+  // -------------------------------------------------------------------------
+  // Refs
+  // -------------------------------------------------------------------------
+  /** Mirror of activeTouches for safe access inside setTimeout callbacks. */
+  const activeTouchesRef = useRef<Touch[]>([]);
+  const maxMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    activeTouchesRef.current = activeTouches;
+  }, [activeTouches]);
+
+  // -------------------------------------------------------------------------
+  // Derived values
+  // -------------------------------------------------------------------------
+
+  /**
+   * A stable string key representing the *identity* of the active touch set
+   * (sorted IDs joined). Changes only when touches are added or removed —
+   * NOT when fingers move — so countdown timers reset on add/remove only.
+   */
+  const touchIdentityKey = useMemo(
+    () => activeTouches.map((t) => t.id).sort().join(','),
+    [activeTouches],
+  );
+
+  const touchCount = activeTouches.length;
+
+  // -------------------------------------------------------------------------
+  // TouchSurface callbacks
+  // -------------------------------------------------------------------------
+
+  /**
+   * Merges incoming raw touches with the existing state to preserve colour
+   * assignments for touches that are still active.
+   */
+  const handleTouchesChange = useCallback((rawTouches: RawTouchPoint[]) => {
+    setActiveTouches((prevTouches) => {
+      const prevMap = new Map<string, Touch>(prevTouches.map((t) => [t.id, t]));
+
+      // Colours currently in use by continuing touches (not lifted ones).
+      const continuingIds = new Set(rawTouches.map((r) => r.id));
+      const usedColors = new Set(
+        prevTouches.filter((t) => continuingIds.has(t.id)).map((t) => t.color),
+      );
+
+      return rawTouches.map((raw) => {
+        const existing = prevMap.get(raw.id);
+        if (existing) {
+          // Finger still down — update position, keep colour.
+          return { ...existing, x: raw.x, y: raw.y, timestamp: Date.now() };
+        }
+        // New finger — assign the first unused lottery colour.
+        const color =
+          (LOTTERY_COLORS as readonly string[]).find(
+            (c) => !usedColors.has(c),
+          ) ?? LOTTERY_COLORS[0];
+        usedColors.add(color);
+        return {
+          id: raw.id,
+          x: raw.x,
+          y: raw.y,
+          timestamp: Date.now(),
+          color,
+        };
+      });
+    });
+  }, []);
+
+  /** Shows the "max players" message for 2 seconds when a 9th touch is rejected. */
+  const handleMaxTouchesExceeded = useCallback(() => {
+    setShowMaxMessage(true);
+    if (maxMessageTimerRef.current !== null) {
+      clearTimeout(maxMessageTimerRef.current);
+    }
+    maxMessageTimerRef.current = setTimeout(() => {
+      setShowMaxMessage(false);
+      maxMessageTimerRef.current = null;
+    }, 2000);
+  }, []);
+
+  // Cleanup max-message timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (maxMessageTimerRef.current !== null) {
+        clearTimeout(maxMessageTimerRef.current);
+      }
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Countdown timer effects
+  // -------------------------------------------------------------------------
+
+  /**
+   * Visual countdown: counts 3 → 2 → 1 while touches are stable (≥ MIN_PLAYERS).
+   * Resets whenever the touch identity changes or a winner is already selected.
+   */
+  useEffect(() => {
+    if (winner !== null || touchCount < MIN_PLAYERS) {
+      setCountdown(null);
+      return;
+    }
+
+    setCountdown(3);
+    const intervalId = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(intervalId);
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [touchIdentityKey, winner, touchCount]);
+  // Note: touchIdentityKey encodes touch identity; touchCount guards the < 2 check.
+
+  /**
+   * Winner selection: after `LOTTERY_STABILITY_MS` of stable touches (≥ MIN_PLAYERS),
+   * select a random winner via `LotteryEngine.selectWinner()`.
+   * Resets whenever the touch identity changes or a winner is already selected.
+   */
+  useEffect(() => {
+    if (winner !== null || touchCount < MIN_PLAYERS) return;
+
+    const timeoutId = setTimeout(() => {
+      const touches = activeTouchesRef.current;
+      if (touches.length >= MIN_PLAYERS) {
+        setWinner(LotteryEngine.selectWinner(touches));
+      }
+    }, LOTTERY_STABILITY_MS);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [touchIdentityKey, winner, touchCount]);
+  // activeTouchesRef.current is accessed inside the timeout — no closure staleness.
+
+  // -------------------------------------------------------------------------
+  // Play Again
+  // -------------------------------------------------------------------------
+
+  /** Resets all state and remounts TouchSurface for a fresh round. */
+  const handlePlayAgain = useCallback(() => {
+    setWinner(null);
+    setActiveTouches([]);
+    setCountdown(null);
+    setShowMaxMessage(false);
+    setRoundKey((k) => k + 1);
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Render helpers
+  // -------------------------------------------------------------------------
+
+  const winnerColorName = winner ? (COLOR_NAMES[winner.color] ?? 'Unknown') : null;
+
+  /** Status message shown at the top of the surface during non-winner phases. */
+  const statusMessage: string | null = (() => {
+    if (winner !== null) return null; // Winner overlay takes over.
+    if (touchCount === 0) return 'Place your fingers on the screen';
+    if (touchCount === 1) return 'Add more fingers to play';
+    if (countdown !== null) return `Selecting in ${countdown}…`;
+    return null;
+  })();
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Lottery</Text>
+      {/* Full-screen touch surface — disabled once a winner is selected. */}
+      <TouchSurface
+        key={roundKey}
+        onTouchesChange={handleTouchesChange}
+        onMaxTouchesExceeded={handleMaxTouchesExceeded}
+        maxTouches={MAX_LOTTERY_TOUCHES}
+        disabled={winner !== null}
+      >
+        {/* Touch circles — one per active touch. */}
+        {activeTouches.map((touch) => (
+          <TouchCircle
+            key={touch.id}
+            x={touch.x}
+            y={touch.y}
+            color={touch.color}
+            isWinner={winner?.id === touch.id}
+            growing={winner?.id === touch.id}
+            fading={winner !== null && winner.id !== touch.id}
+          />
+        ))}
+
+        {/* Status message overlay (non-interactive — passes through to surface). */}
+        {statusMessage !== null && (
+          <View
+            style={styles.statusOverlay}
+            pointerEvents="none"
+            accessibilityLiveRegion="polite"
+          >
+            <Text style={styles.statusText} accessibilityRole="text">
+              {statusMessage}
+            </Text>
+          </View>
+        )}
+
+        {/* "Max players" transient message. */}
+        {showMaxMessage && (
+          <View
+            style={styles.maxMessageOverlay}
+            pointerEvents="none"
+            accessibilityLiveRegion="assertive"
+          >
+            <Text style={styles.maxMessageText}>
+              Maximum {MAX_LOTTERY_TOUCHES} players reached
+            </Text>
+          </View>
+        )}
+
+        {/* Winner announcement — shown inside surface for visual alignment. */}
+        {winner !== null && (
+          <View
+            style={styles.winnerOverlay}
+            pointerEvents="none"
+            accessibilityLiveRegion="assertive"
+          >
+            <Text
+              style={styles.winnerTitle}
+              accessibilityRole="header"
+            >
+              We have a winner!
+            </Text>
+            <Text
+              style={[styles.winnerColorLabel, { color: winner.color }]}
+              accessibilityLabel={`${winnerColorName} circle wins`}
+            >
+              {winnerColorName}
+            </Text>
+          </View>
+        )}
+      </TouchSurface>
+
+      {/* Play Again button — rendered outside TouchSurface so it receives taps. */}
+      {winner !== null && (
+        <View style={styles.playAgainContainer}>
+          <TouchableOpacity
+            style={styles.playAgainButton}
+            onPress={handlePlayAgain}
+            accessibilityRole="button"
+            accessibilityLabel="Play Again"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text style={styles.playAgainLabel}>Play Again</Text>
+          </TouchableOpacity>
+        </View>
+      )}
     </View>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+/** Dark game-table background colour — provides contrast for coloured circles. */
+const SURFACE_BACKGROUND = '#1A1A2E';
+/** Semi-transparent overlay background for status messages. */
+const OVERLAY_BG = 'rgba(0, 0, 0, 0.55)';
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: SURFACE_BACKGROUND,
+  },
+
+  // ---- Touch circle overlay (status messages) ----
+
+  statusOverlay: {
+    position: 'absolute',
+    top: spacing.xxl,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  statusText: {
+    ...typography.h3,
+    color: '#FFFFFF',
+    textAlign: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    backgroundColor: OVERLAY_BG,
+    borderRadius: 24,
+    overflow: 'hidden',
+  },
+
+  // ---- Max players message ----
+
+  maxMessageOverlay: {
+    position: 'absolute',
+    bottom: spacing.xxxl + spacing.xxl,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  maxMessageText: {
+    ...typography.bodyMedium,
+    color: '#FFFFFF',
+    textAlign: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    backgroundColor: 'rgba(191, 54, 12, 0.85)', // Semantic warning with opacity
+    borderRadius: 24,
+    overflow: 'hidden',
+  },
+
+  // ---- Winner announcement ----
+
+  winnerOverlay: {
+    position: 'absolute',
+    top: spacing.xxl,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  winnerTitle: {
+    ...typography.h2,
+    color: '#FFFFFF',
+    textAlign: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    backgroundColor: OVERLAY_BG,
+    borderRadius: 24,
+    overflow: 'hidden',
+  },
+  winnerColorLabel: {
+    fontSize: 40,
+    fontWeight: '800' as const,
+    textAlign: 'center',
+    // Drop shadow for legibility on any background.
+    textShadowColor: 'rgba(0, 0, 0, 0.6)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 4,
+  },
+
+  // ---- Play Again button ----
+
+  playAgainContainer: {
+    position: 'absolute',
+    bottom: spacing.xxxl,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  playAgainButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.xxl,
+    paddingVertical: spacing.md,
+    borderRadius: 32,
+    minWidth: 160,
+    minHeight: 48,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#fff',
+    // Shadow
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 8,
+    elevation: 10,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  playAgainLabel: {
+    ...typography.bodyMedium,
+    color: '#FFFFFF',
+    fontWeight: '700' as const,
   },
 });

--- a/src/services/lottery/LotteryEngine.ts
+++ b/src/services/lottery/LotteryEngine.ts
@@ -1,0 +1,34 @@
+/**
+ * LotteryEngine — stateless service for the multi-touch player selection feature.
+ *
+ * Provides random winner selection from a list of active touch points.
+ * All methods are pure and stateless — state is managed in the UI layer (LotteryScreen).
+ *
+ * Per the architecture (§7 API Boundaries):
+ *   - trackTouches: handled by TouchSurface component
+ *   - isStable:     handled by countdown timer in LotteryScreen
+ *   - selectWinner: implemented here
+ */
+
+import { Touch } from '../../types/Touch';
+
+export class LotteryEngine {
+  /**
+   * Randomly selects one touch as the lottery winner.
+   *
+   * Uses `Math.random()` for selection — no cryptographic guarantees,
+   * which is acceptable for casual board game fairness (FR-L6).
+   * Each touch has an equal probability of 1/N of being selected.
+   *
+   * @param touches - Active touches to select from. Must be non-empty.
+   * @returns The selected winning `Touch`.
+   * @throws Error if `touches` is empty.
+   */
+  static selectWinner(touches: Touch[]): Touch {
+    if (touches.length === 0) {
+      throw new Error('Cannot select a winner from an empty touches array.');
+    }
+    const index = Math.floor(Math.random() * touches.length);
+    return touches[index];
+  }
+}


### PR DESCRIPTION
## Summary
Implements the Lottery feature screen with full-screen multi-touch detection, animated colored circles for each touch point, 3-second stability countdown, and random winner selection via `LotteryEngine.selectWinner()`.

Closes #16

## Changes
- **`src/screens/lottery/LotteryScreen.tsx`** — Full implementation replacing the stub. Manages touch state, color assignment, countdown timers, winner selection, and Play Again reset.
- **`src/components/lottery/TouchSurface.tsx`** — Full-screen `Gesture.Manual()` + `GestureDetector` surface from React Native Gesture Handler. Tracks up to 8 simultaneous touches; rejects the 9th with a callback.
- **`src/components/lottery/TouchCircle.tsx`** — Animated circle for each touch point. Spring appear animation, winner grow, non-winner fade-out via built-in Animated API.
- **`src/services/lottery/LotteryEngine.ts`** — Stateless service with `selectWinner(touches)` using `Math.random()` for fair casual selection (FR-L6).

## Design Decisions
- **`Gesture.Manual()` over `PanGestureHandler`**: The issue mentions PanGestureHandler, but `Gesture.Manual()` from RNGH v2 is the correct API for tracking independent touch IDs. PanGestureHandler handles a single composite gesture.
- **`GestureHandlerRootView` in `TouchSurface`**: App.tsx has no root wrapper, so the surface wraps itself. Nested `GestureHandlerRootView` is supported by RNGH.
- **Ref-based callbacks in `TouchSurface`**: The gesture is created once (`useMemo` with empty deps) and reads all mutable state through refs, avoiding gesture recreation on re-renders.
- **`touchIdentityKey` for timer reset**: The countdown resets only when the set of touch IDs changes (add/remove), NOT on moves — matching FR-L9 precisely.
- **`LotteryEngine` as a new service**: Not in the estimated files but required for `LotteryScreen` to compile. Follows the same static class pattern as `DiceRoller`.

## Acceptance Criteria
- [x] LotteryScreen displays full-screen touch surface
- [x] Touching screen creates colored circles at touch points
- [x] Up to 8 simultaneous touches are tracked and displayed
- [x] 9th touch is ignored with visual feedback message ("Maximum 8 players reached")
- [x] Circles remain visible as long as fingers are on screen
- [x] 3-second countdown begins after touches stabilize (2+ fingers)
- [x] Countdown resets if touches change (add/remove)
- [x] After 3 seconds, `LotteryEngine.selectWinner()` fires (TASK-017 integrates haptics)

## Verification
- [x] Type check passes (`npx tsc --noEmit` — no errors in lottery files)
- [x] Lint passes (`eslint src/components/lottery src/screens/lottery src/services/lottery`)
- [x] Tests pass (6/6 existing tests pass)

## Notes
- TASK-017 (haptic feedback) will hook into the winner selection moment — the `setWinner()` call in `LotteryScreen` is the integration point.
- The one pre-existing TS error (`NewGameDialog.tsx:167`) is unrelated to this task.
