### PR TITLE
feat: Lottery winner selection, WinnerAnnouncement component, and haptic feedback

### DIFF
--- a/src/components/lottery/WinnerAnnouncement.tsx
+++ b/src/components/lottery/WinnerAnnouncement.tsx
@@ -1,0 +1,234 @@
+/**
+ * WinnerAnnouncement — full-screen overlay announcing the Lottery winner.
+ *
+ * Displayed after the 3-second countdown completes and a winner is selected
+ * (FR-L7, FR-L8, FR-L10). Responsibilities:
+ *   - Fade-in overlay to emphasise the winner without abruptly hiding circles.
+ *   - "Player in [Color] circle wins!" message with the winner's color.
+ *   - A "Play Again" button that triggers a full round reset (FR-L10).
+ *
+ * Animations use the built-in React Native Animated API (ADR-4).
+ * All text elements meet WCAG AA contrast on the dark overlay (NFR-A1).
+ */
+
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { colors, spacing, typography } from '../../styles/theme';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Duration of the overlay fade-in animation in milliseconds. */
+const FADE_IN_DURATION_MS = 400;
+
+/** Semi-transparent overlay — dark enough for legibility, light enough to show circles beneath. */
+const OVERLAY_BG = 'rgba(0, 0, 0, 0.65)';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface WinnerAnnouncementProps {
+  /**
+   * Hex color string of the winning touch circle.
+   * Must be a WCAG AA compliant lottery color.
+   */
+  winnerColor: string;
+  /**
+   * Human-readable name for the winning color (e.g., "Red", "Blue").
+   * Included in the winner message and accessibility label.
+   */
+  winnerColorName: string;
+  /** Callback invoked when the user taps "Play Again". */
+  onPlayAgain: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Animated full-screen overlay that announces the Lottery winner.
+ * Fades in on mount and renders above all other content.
+ */
+export function WinnerAnnouncement({
+  winnerColor,
+  winnerColorName,
+  onPlayAgain,
+}: WinnerAnnouncementProps): React.JSX.Element {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  // Fade in the overlay when the component mounts.
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: FADE_IN_DURATION_MS,
+      useNativeDriver: true,
+    }).start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Run once on mount only.
+
+  const winnerMessage = `Player in ${winnerColorName} circle wins!`;
+
+  return (
+    <Animated.View
+      style={[styles.overlay, { opacity: fadeAnim }]}
+      // Overlay is informational — accessible announcement via liveRegion.
+      accessibilityLiveRegion="assertive"
+    >
+      {/* Inner container — vertically centred announcement card. */}
+      <View
+        style={styles.card}
+        accessibilityRole="alert"
+        accessible
+        accessibilityLabel={winnerMessage}
+      >
+        <Text style={styles.title} accessibilityRole="header">
+          We have a winner!
+        </Text>
+
+        {/* Color swatch + name — primary visual indicator of the winner. */}
+        <View style={styles.colorRow}>
+          <View
+            style={[styles.colorSwatch, { backgroundColor: winnerColor }]}
+            accessibilityElementsHidden
+          />
+          <Text
+            style={[styles.colorName, { color: winnerColor }]}
+            accessibilityElementsHidden
+          >
+            {winnerColorName}
+          </Text>
+        </View>
+
+        {/* Subtitle with full readable announcement for screen readers. */}
+        <Text
+          style={styles.subtitle}
+          accessibilityLabel={winnerMessage}
+        >
+          {winnerMessage}
+        </Text>
+      </View>
+
+      {/* Play Again button — outside the card so it stands out as an action. */}
+      <TouchableOpacity
+        style={styles.playAgainButton}
+        onPress={onPlayAgain}
+        accessibilityRole="button"
+        accessibilityLabel="Play Again"
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Text style={styles.playAgainLabel}>Play Again</Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: OVERLAY_BG,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xl,
+    // Ensure overlay is above touch circles rendered behind it.
+    zIndex: 10,
+  },
+
+  card: {
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    borderRadius: 24,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xl,
+    alignItems: 'center',
+    gap: spacing.sm,
+    // Subtle border for definition against overlay.
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    // Shadow for depth.
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.5,
+    shadowRadius: 16,
+    elevation: 16,
+  },
+
+  title: {
+    ...typography.h2,
+    color: '#FFFFFF',
+    textAlign: 'center',
+  },
+
+  colorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.xs,
+  },
+
+  colorSwatch: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 2,
+    borderColor: '#FFFFFF',
+    // Shadow so the swatch reads against any background.
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.4,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+
+  colorName: {
+    fontSize: 40,
+    fontWeight: '800' as const,
+    textAlign: 'center',
+    // Drop shadow for legibility on any background.
+    textShadowColor: 'rgba(0, 0, 0, 0.6)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 4,
+  },
+
+  subtitle: {
+    ...typography.bodyMedium,
+    color: '#FFFFFF',
+    textAlign: 'center',
+    marginTop: spacing.xs,
+  },
+
+  playAgainButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.xxl,
+    paddingVertical: spacing.md,
+    borderRadius: 32,
+    minWidth: 160,
+    minHeight: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Shadow for prominence.
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 8,
+    elevation: 10,
+  },
+
+  playAgainLabel: {
+    ...typography.bodyMedium,
+    color: '#FFFFFF',
+    fontWeight: '700' as const,
+  },
+});

--- a/src/screens/lottery/LotteryScreen.tsx
+++ b/src/screens/lottery/LotteryScreen.tsx
@@ -32,7 +32,7 @@ import React, {
 import {
   StyleSheet,
   Text,
-  TouchableOpacity,
+  Vibration,
   View,
 } from 'react-native';
 
@@ -41,9 +41,10 @@ import {
   RawTouchPoint,
   TouchSurface,
 } from '../../components/lottery/TouchSurface';
+import { WinnerAnnouncement } from '../../components/lottery/WinnerAnnouncement';
 import { RootStackScreenProps } from '../../navigation/types';
 import { LotteryEngine } from '../../services/lottery/LotteryEngine';
-import { colors, spacing, typography } from '../../styles/theme';
+import { spacing, typography } from '../../styles/theme';
 import { Touch } from '../../types/Touch';
 import {
   LOTTERY_STABILITY_MS,
@@ -229,6 +230,8 @@ export default function LotteryScreen(_props: Props): React.JSX.Element {
     const timeoutId = setTimeout(() => {
       const touches = activeTouchesRef.current;
       if (touches.length >= MIN_PLAYERS) {
+        // Haptic feedback signals countdown completion (FR-L5, ADR-14).
+        Vibration.vibrate(100);
         setWinner(LotteryEngine.selectWinner(touches));
       }
     }, LOTTERY_STABILITY_MS);
@@ -321,42 +324,15 @@ export default function LotteryScreen(_props: Props): React.JSX.Element {
           </View>
         )}
 
-        {/* Winner announcement — shown inside surface for visual alignment. */}
-        {winner !== null && (
-          <View
-            style={styles.winnerOverlay}
-            pointerEvents="none"
-            accessibilityLiveRegion="assertive"
-          >
-            <Text
-              style={styles.winnerTitle}
-              accessibilityRole="header"
-            >
-              We have a winner!
-            </Text>
-            <Text
-              style={[styles.winnerColorLabel, { color: winner.color }]}
-              accessibilityLabel={`${winnerColorName} circle wins`}
-            >
-              {winnerColorName}
-            </Text>
-          </View>
-        )}
       </TouchSurface>
 
-      {/* Play Again button — rendered outside TouchSurface so it receives taps. */}
-      {winner !== null && (
-        <View style={styles.playAgainContainer}>
-          <TouchableOpacity
-            style={styles.playAgainButton}
-            onPress={handlePlayAgain}
-            accessibilityRole="button"
-            accessibilityLabel="Play Again"
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <Text style={styles.playAgainLabel}>Play Again</Text>
-          </TouchableOpacity>
-        </View>
+      {/* Winner announcement — rendered outside TouchSurface so it receives taps. */}
+      {winner !== null && winnerColorName !== null && (
+        <WinnerAnnouncement
+          winnerColor={winner.color}
+          winnerColorName={winnerColorName}
+          onPlayAgain={handlePlayAgain}
+        />
       )}
     </View>
   );
@@ -417,64 +393,4 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
 
-  // ---- Winner announcement ----
-
-  winnerOverlay: {
-    position: 'absolute',
-    top: spacing.xxl,
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-    gap: spacing.xs,
-  },
-  winnerTitle: {
-    ...typography.h2,
-    color: '#FFFFFF',
-    textAlign: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.sm,
-    backgroundColor: OVERLAY_BG,
-    borderRadius: 24,
-    overflow: 'hidden',
-  },
-  winnerColorLabel: {
-    fontSize: 40,
-    fontWeight: '800' as const,
-    textAlign: 'center',
-    // Drop shadow for legibility on any background.
-    textShadowColor: 'rgba(0, 0, 0, 0.6)',
-    textShadowOffset: { width: 0, height: 2 },
-    textShadowRadius: 4,
-  },
-
-  // ---- Play Again button ----
-
-  playAgainContainer: {
-    position: 'absolute',
-    bottom: spacing.xxxl,
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  playAgainButton: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: spacing.xxl,
-    paddingVertical: spacing.md,
-    borderRadius: 32,
-    minWidth: 160,
-    minHeight: 48,
-    alignItems: 'center',
-    justifyContent: 'center',
-    // Shadow
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.4,
-    shadowRadius: 8,
-    elevation: 10,
-  },
-  playAgainLabel: {
-    ...typography.bodyMedium,
-    color: '#FFFFFF',
-    fontWeight: '700' as const,
-  },
 });


### PR DESCRIPTION
## Summary
Implements Lottery winner selection logic with haptic feedback and the `WinnerAnnouncement` component — completing the end-to-end winner announcement flow (FR-L5 through FR-L10).

Closes #17

## Changes
- **`src/components/lottery/WinnerAnnouncement.tsx`** (new): Full-screen animated overlay displaying the winner's color swatch, "[Color] wins!" message, and a "Play Again" button. Uses the Animated API for a smooth fade-in entrance.
- **`src/screens/lottery/LotteryScreen.tsx`** (modified): Adds `Vibration.vibrate(100)` haptic feedback on countdown completion, imports and renders `WinnerAnnouncement` in place of the previous inline winner UI, and removes the now-unused winner/play-again styles.
- **`src/services/lottery/LotteryEngine.ts`**: Already implemented with `selectWinner()` (no changes required).

## Design Decisions
- **`WinnerAnnouncement` as a separate component**: Extracted from inline LotteryScreen markup to keep concerns separated and enable independent testing. The component handles its own fade-in animation using a `useEffect` on mount.
- **Overlay positioned outside `TouchSurface`**: The announcement renders as a sibling of `TouchSurface` in an absolute-positioned `View`, ensuring it receives tap events for the "Play Again" button (touch events inside `TouchSurface` are already disabled on winner selection).
- **`Vibration` from `react-native` (not `expo-haptics`)**: The spec and ADR-14 explicitly call for `Vibration.vibrate(100)`. `expo-haptics` is in `package.json` for other uses; using the RN core `Vibration` API matches the specification exactly.
- **Fade-in animation**: A 400ms `Animated.timing` opacity animation provides a smooth reveal that doesn't abruptly obscure the growing winner circle.

## Acceptance Criteria
- [x] `LotteryEngine.selectWinner(touches)` returns one random touch from array
- [x] `WinnerAnnouncement` displays winner circle with growth animation (via `TouchCircle` `growing` prop)
- [x] Non-winning circles fade out (via `TouchCircle` `fading` prop)
- [x] Device vibrates (100ms) when winner is announced
- [x] "Play Again" button resets UI and begins new countdown
- [x] Winner announcement is readable and accessible (text + color swatch + accessibility labels)
- [x] Animations run at 60 FPS (Animated API with `useNativeDriver: true`)

## Verification
- [x] Type check passes (`npx tsc --noEmit` — only pre-existing error in `NewGameDialog.tsx`)
- [x] Lint passes (`npx eslint` on modified files — no warnings or errors)
- [x] Tests pass (`npx jest` — 6/6 passing)

## Notes
There is one pre-existing TypeScript error in `src/screens/score/NewGameDialog.tsx` (`Property 'id' does not exist on type 'void'`). This exists on `main` before my changes and is outside my task scope.
