### PR TITLE
feat: implement session restoration on app launch (#18)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,19 @@ import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 
 import { GameStateProvider } from './context/GameStateContext';
+import { useSessionRestore } from './context/hooks/useSessionRestore';
 import RootNavigator from './navigation/RootNavigator';
 import { theme } from './styles/theme';
+
+/**
+ * Inner component rendered inside NavigationContainer so that
+ * useSessionRestore can call useNavigation() to access the navigation context.
+ * Returns null — exists solely to trigger the session restore side-effect.
+ */
+function AppStartup(): null {
+  useSessionRestore();
+  return null;
+}
 
 /**
  * Root application component.
@@ -12,6 +23,7 @@ import { theme } from './styles/theme';
  * Wraps the app with:
  *   - GameStateProvider     — global game state (games list, current game, persistence)
  *   - NavigationContainer   — provides navigation context to the whole tree
+ *   - AppStartup            — restores the last active game session on launch (ADR-15)
  *
  * Deep linking is architecture-ready via the `linking` prop; a full
  * `LinkingOptions` configuration can be added once URL schemes are confirmed.
@@ -21,6 +33,7 @@ export default function App(): React.JSX.Element {
     <GameStateProvider>
       <NavigationContainer>
         <StatusBar style="light" backgroundColor={theme.colors.primary} />
+        <AppStartup />
         <RootNavigator />
       </NavigationContainer>
     </GameStateProvider>

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 
 import { GameRepository } from '../services/storage/GameRepository';
+import { SessionManager } from '../services/storage/SessionManager';
 import { Game, Player } from '../types';
 import { usePersistence } from './hooks/usePersistence';
 
@@ -202,6 +203,8 @@ export function GameStateProvider({ children }: GameStateProviderProps): React.J
 
   /**
    * Loads a game from the games array and sets it as the current active game.
+   * Also persists the game ID via SessionManager so it can be restored on
+   * the next app launch (ADR-15).
    */
   const resumeGame = useCallback(
     async (gameId: string): Promise<void> => {
@@ -210,6 +213,7 @@ export function GameStateProvider({ children }: GameStateProviderProps): React.J
 
       try {
         await GameRepository.saveLastGameId(gameId);
+        await SessionManager.saveLastGameId(gameId);
         dispatch({ type: 'SET_CURRENT_GAME', game });
         dispatch({ type: 'SET_LAST_GAME_ID', id: gameId });
       } catch (error) {

--- a/src/context/hooks/useSessionRestore.ts
+++ b/src/context/hooks/useSessionRestore.ts
@@ -1,0 +1,65 @@
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useEffect, useRef } from 'react';
+import { Alert } from 'react-native';
+
+import { RootStackParamList } from '../../navigation/types';
+import { SessionManager } from '../../services/storage/SessionManager';
+import { useGameState } from './useGameState';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+
+/**
+ * Restores the last active game session on app launch (ADR-15, FR-S12).
+ *
+ * Must be called from a component rendered inside NavigationContainer so
+ * that useNavigation() can access the navigation context.
+ *
+ * Behaviour:
+ * - Waits for GameStateContext hydration to complete before acting.
+ * - Runs once per app lifecycle (guarded by a ref).
+ * - If the last game ID exists and the game is in the games array:
+ *     sets it as currentGame and navigates to ScoreGame.
+ * - If the last game ID exists but the game was deleted:
+ *     navigates to ScoreHome and shows an alert (ADR-15).
+ * - If no last game ID exists: does nothing; app starts on Home.
+ *
+ * The restore runs asynchronously and does not block the initial render,
+ * keeping app startup time under 1 second.
+ */
+export function useSessionRestore(): void {
+  const { games, loading, resumeGame } = useGameState();
+  const navigation = useNavigation<NavigationProp>();
+  const hasRestoredRef = useRef(false);
+
+  useEffect(() => {
+    // Wait for context hydration before attempting restore
+    if (loading) return;
+
+    // Only restore once per app lifecycle to prevent repeated navigation
+    if (hasRestoredRef.current) return;
+    hasRestoredRef.current = true;
+
+    const restore = async (): Promise<void> => {
+      const lastGameId = await SessionManager.getLastGameId();
+      if (!lastGameId) return;
+
+      const game = games.find((g) => g.id === lastGameId);
+
+      if (game) {
+        // Game still exists — resume and navigate to it
+        await resumeGame(game.id);
+        navigation.navigate('ScoreGame', { gameId: game.id });
+      } else {
+        // Game was deleted — fall back to ScoreHome (ADR-15)
+        await SessionManager.clearLastGameId();
+        navigation.navigate('ScoreHome');
+        Alert.alert('Last game was deleted; here are your saved games');
+      }
+    };
+
+    restore().catch((error) => {
+      console.error('[useSessionRestore] Failed to restore session:', error);
+    });
+  }, [loading, games, resumeGame, navigation]);
+}

--- a/src/services/storage/SessionManager.ts
+++ b/src/services/storage/SessionManager.ts
@@ -1,0 +1,53 @@
+import { AsyncStorageService } from './AsyncStorageService';
+
+const LAST_ACTIVE_GAME_ID_KEY = '@lastActiveGameId';
+
+/**
+ * Manages session persistence for the last active game.
+ *
+ * Stores and retrieves the ID of the most recently active game so the app
+ * can restore the user's session on launch (ADR-15).
+ *
+ * Uses the same storage key as GameRepository to remain consistent with the
+ * shared persisted state; this class is the dedicated interface for session
+ * operations called from useSessionRestore and GameStateContext.
+ */
+export class SessionManager {
+  /**
+   * Persists the ID of the last active game to storage.
+   */
+  static async saveLastGameId(gameId: string): Promise<void> {
+    try {
+      await AsyncStorageService.setItem(LAST_ACTIVE_GAME_ID_KEY, gameId);
+    } catch (error) {
+      console.error('[SessionManager] Failed to save last game ID:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieves the ID of the last active game.
+   * Returns null if no previous session was recorded.
+   */
+  static async getLastGameId(): Promise<string | null> {
+    try {
+      return await AsyncStorageService.getItem(LAST_ACTIVE_GAME_ID_KEY);
+    } catch (error) {
+      console.error('[SessionManager] Failed to get last game ID:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Removes the last active game ID from storage.
+   * Called when the referenced game has been deleted (ADR-15).
+   */
+  static async clearLastGameId(): Promise<void> {
+    try {
+      await AsyncStorageService.removeItem(LAST_ACTIVE_GAME_ID_KEY);
+    } catch (error) {
+      console.error('[SessionManager] Failed to clear last game ID:', error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements automatic session restoration on app launch per ADR-15. When the app is reopened, the last active game is loaded and the user is navigated directly to `ScoreGame`. If the game was deleted, the app falls back to `ScoreHome` with an informative alert.

Closes #18

## Changes
- **`src/services/storage/SessionManager.ts`** (new) — Static service wrapping `AsyncStorageService` with typed methods for the `@lastActiveGameId` key (`saveLastGameId`, `getLastGameId`, `clearLastGameId`)
- **`src/context/hooks/useSessionRestore.ts`** (new) — Hook that waits for context hydration, reads the last game ID via `SessionManager`, sets it as `currentGame` and navigates to `ScoreGame` if found; otherwise navigates to `ScoreHome` and shows an alert per ADR-15
- **`src/App.tsx`** (modified) — Added `AppStartup` inner component rendered inside `NavigationContainer` that calls `useSessionRestore()`, giving the hook access to navigation context
- **`src/context/GameStateContext.tsx`** (modified) — Updated `resumeGame()` to also call `SessionManager.saveLastGameId()` so session data is written via the dedicated service

## Design Decisions
- **`AppStartup` pattern in App.tsx**: `useSessionRestore` requires `useNavigation()`, which must be called inside `NavigationContainer`. Rather than polluting `RootNavigator`, a minimal `AppStartup` null-rendering component handles the side effect cleanly.
- **`useRef` guard**: A `hasRestoredRef` ref ensures the restore logic runs exactly once per app lifecycle, even if `loading` or `games` cause the effect to re-evaluate.
- **`SessionManager` key alignment**: Uses the same `@lastActiveGameId` AsyncStorage key as `GameRepository` to stay consistent with existing persisted state; `SessionManager` is the new dedicated interface for session reads within `useSessionRestore`.
- **Alert for deleted-game toast**: No toast library exists in the project; `Alert.alert()` provides a cross-platform notification per the issue's "simple Alert" suggestion.

## Acceptance Criteria
- [x] On app launch, `useSessionRestore()` loads last game ID from storage
- [x] If game exists in games array, it is loaded as `currentGame`
- [x] Navigation automatically opens `ScoreGame` with last game on startup
- [x] If game was deleted, app falls back to `ScoreHome` and shows toast message
- [x] Toast displays: "Last game was deleted; here are your saved games"
- [x] `SessionManager.saveLastGameId()` is called whenever `resumeGame()` is called
- [x] App startup time remains under 1 second (restore is non-blocking via async effect)

## Verification
- [x] Type check passes (`npx tsc --noEmit` — only one pre-existing unrelated error in `NewGameDialog.tsx`)
- [x] Lint passes (only pre-existing errors in `GameDeleteModal.tsx` unrelated to this task)
- [x] Tests pass (6/6 existing tests pass)

## Notes
- The pre-existing TypeScript error in `src/screens/score/NewGameDialog.tsx(167,26)` and ESLint errors in `GameDeleteModal.tsx` are unrelated to this task and were present before these changes.
